### PR TITLE
Modify(#96): 공공 데이터포털 오류로 인한 에러 때문에 findByPlaceId에 limit 걸기

### DIFF
--- a/src/main/java/shop/babsim/babsim/place/domain/repository/PlaceRepository.java
+++ b/src/main/java/shop/babsim/babsim/place/domain/repository/PlaceRepository.java
@@ -14,6 +14,7 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceCustom
 
     Optional<Place> findByBusinessName(String businessName);
 
+    @Query(value = "SELECT * FROM place WHERE place_id = :placeId LIMIT 1", nativeQuery = true)
     Optional<Place> findByPlaceId(String placeId);
 
     @Query("""


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #96 

## 📝작업 내용

> 공공 데이터포털 오류로 인한 에레 때문에 findByPlaceId에 limit 걸기


