### PR TITLE
Feature(#112): 회원 탈퇴 api

### DIFF
--- a/src/main/java/shop/babsim/babsim/auth/application/AuthMemberService.java
+++ b/src/main/java/shop/babsim/babsim/auth/application/AuthMemberService.java
@@ -64,8 +64,15 @@ public class AuthMemberService {
     }
 
     private String unionName(String name, String nickname) {
-        return nickname != null ? nickname : name;
+        if (nickname != null && !nickname.isBlank()) {
+            return nickname;
+        } else if (name != null && !name.isBlank()) {
+            return name;
+        } else {
+            return "밥심프렌드";
+        }
     }
+
 
     private String getUserPicture(String picture) {
         return Optional.ofNullable(picture)

--- a/src/main/java/shop/babsim/babsim/auth/application/AuthMemberService.java
+++ b/src/main/java/shop/babsim/babsim/auth/application/AuthMemberService.java
@@ -42,8 +42,15 @@ public class AuthMemberService {
 
     private Member getExistingMemberOrCreateNew(UserInfo userInfo, SocialType provider, String providerRefreshToken) {
         return memberRepository.findByEmail(userInfo.email())
+                .map(existingMember -> {
+                    if (providerRefreshToken != null && !providerRefreshToken.isBlank()) {
+                        existingMember.updateProviderRefreshToken(providerRefreshToken);
+                    }
+                    return existingMember;
+                })
                 .orElseGet(() -> createMember(userInfo, provider, providerRefreshToken));
     }
+
 
     private Member createMember(UserInfo userInfo, SocialType provider, String providerRefreshToken) {
         String name = unionName(userInfo.name(), userInfo.nickname());

--- a/src/main/java/shop/babsim/babsim/member/domain/Member.java
+++ b/src/main/java/shop/babsim/babsim/member/domain/Member.java
@@ -99,4 +99,9 @@ public class Member extends BaseEntity {
         this.picture = picture;
         this.nickname = nickName;
     }
+
+    public void updateProviderRefreshToken(String refreshToken) {
+        this.providerRefreshToken = refreshToken;
+    }
+
 }

--- a/src/test/java/shop/babsim/babsim/auth/application/AuthMemberServiceTest.java
+++ b/src/test/java/shop/babsim/babsim/auth/application/AuthMemberServiceTest.java
@@ -37,7 +37,7 @@ class AuthMemberServiceTest {
     void shouldThrowException_whenEmailIsNull() {
         UserInfo userInfo = new UserInfo(null, "인호", "인호사진", "인호");
 
-        assertThatThrownBy(() -> authMemberService.saveUserInfo(userInfo, SocialType.GOOGLE))
+        assertThatThrownBy(() -> authMemberService.saveUserInfo(userInfo, SocialType.GOOGLE, "refreshToken"))
                 .isInstanceOf(EmailNotFoundException.class);
     }
 
@@ -62,7 +62,7 @@ class AuthMemberServiceTest {
         when(memberRepository.save(any(Member.class))).thenReturn(newMember);
 
         // when
-        MemberLoginResDto result = authMemberService.saveUserInfo(userInfo, SocialType.GOOGLE);
+        MemberLoginResDto result = authMemberService.saveUserInfo(userInfo, SocialType.GOOGLE, "refreshToken");
 
         // then
         assertThat(result.findMember().getEmail()).isEqualTo(userInfo.email());
@@ -89,7 +89,7 @@ class AuthMemberServiceTest {
         when(memberRepository.findByEmail(userInfo.email())).thenReturn(Optional.of(existingMember));
 
         // when
-        MemberLoginResDto result = authMemberService.saveUserInfo(userInfo, SocialType.GOOGLE);
+        MemberLoginResDto result = authMemberService.saveUserInfo(userInfo, SocialType.GOOGLE, "refreshToken");
 
         // then
         assertThat(result.findMember().getEmail()).isEqualTo(userInfo.email());
@@ -108,7 +108,7 @@ class AuthMemberServiceTest {
 
         when(memberRepository.findByEmail(userInfo.email())).thenReturn(Optional.of(existingMember));
 
-        assertThatThrownBy(() -> authMemberService.saveUserInfo(userInfo, SocialType.GOOGLE))
+        assertThatThrownBy(() -> authMemberService.saveUserInfo(userInfo, SocialType.GOOGLE, "refreshToken"))
                 .isInstanceOf(ExistsMemberEmailException.class);
     }
 }

--- a/src/test/java/shop/babsim/babsim/global/jwt/TokenProviderTest.java
+++ b/src/test/java/shop/babsim/babsim/global/jwt/TokenProviderTest.java
@@ -52,7 +52,7 @@ class TokenProviderTest {
         // when
         TokenDto tokenDto = tokenProvider.generateToken(email);
         String accessToken = tokenDto.accessToken();
-        TokenReqDto tokenReqDto = new TokenReqDto(accessToken);
+        TokenReqDto tokenReqDto = new TokenReqDto(accessToken, null);
         String parsedEmail = tokenProvider.getUserEmailFromToken(tokenReqDto);
 
         // then

--- a/src/test/java/shop/babsim/babsim/review/ReviewServiceTest.java
+++ b/src/test/java/shop/babsim/babsim/review/ReviewServiceTest.java
@@ -109,10 +109,15 @@ class ReviewServiceTest {
         Long reviewId = 1L;
         Member member = mock(Member.class);
 
+        Place place = mock(Place.class);
+        when(place.getBusinessName()).thenReturn("테스트 식당");
+
         Review review = mock(Review.class);
-        when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
         when(review.getFeedImage()).thenReturn("imageKey");
         when(review.getMember()).thenReturn(member);
+        when(review.getPlace()).thenReturn(place);
+
+        when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
         when(awsS3Service.getFileUrls("imageKey")).thenReturn("https://s3.com/image.jpg");
 
         ReviewInfoResDto result = reviewService.findById(reviewId);
@@ -120,6 +125,7 @@ class ReviewServiceTest {
         assertThat(result).isNotNull();
         verify(reviewRepository).findById(reviewId);
     }
+
 
     @Test
     @DisplayName("리뷰 ID로 조회 실패 - 존재하지 않음")


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #88 

## 📝작업 내용

> 회원 탈퇴 로직 소셜로 접근해서 탈퇴하는 방식으로 구현 (카카오, 구글, 애플)

> 회원 탈퇴를 위해서 리프레쉬 토큰을 저장하도록 수정

> 리프레시 토큰이 로그인 할 때마다 업데이트 되도록 수정



