### PR TITLE
Bug(#123): 애플 로그인 최초 회원가입 버그 잡기 - 임시 DB

### DIFF
--- a/src/main/java/shop/babsim/babsim/auth/domain/ApplePreSignup.java
+++ b/src/main/java/shop/babsim/babsim/auth/domain/ApplePreSignup.java
@@ -1,0 +1,30 @@
+package shop.babsim.babsim.auth.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import shop.babsim.babsim.global.entity.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ApplePreSignup extends BaseEntity{
+
+    @Column(nullable = false, unique = true)
+    private String sub;
+
+    @Column(nullable = false)
+    private String email;
+
+    private String name;
+
+    public static ApplePreSignup of(String sub, String email, String name) {
+        return ApplePreSignup.builder()
+                .sub(sub)
+                .email(email)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/shop/babsim/babsim/auth/domain/repository/ApplePreSignupRepository.java
+++ b/src/main/java/shop/babsim/babsim/auth/domain/repository/ApplePreSignupRepository.java
@@ -1,0 +1,10 @@
+package shop.babsim.babsim.auth.domain.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import shop.babsim.babsim.auth.domain.ApplePreSignup;
+
+public interface ApplePreSignupRepository extends JpaRepository<ApplePreSignup, Long> {
+    boolean existsBySub(String sub);
+    Optional<ApplePreSignup> findBySub(String sub);
+}

--- a/src/main/java/shop/babsim/babsim/global/oauth/AppleAuthService.java
+++ b/src/main/java/shop/babsim/babsim/global/oauth/AppleAuthService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.Base64;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
@@ -19,6 +20,8 @@ import org.springframework.web.client.RestTemplate;
 import shop.babsim.babsim.auth.api.dto.request.IdTokenAndRefreshTokenDto;
 import shop.babsim.babsim.auth.api.dto.response.UserInfo;
 import shop.babsim.babsim.auth.application.AuthService;
+import shop.babsim.babsim.auth.domain.ApplePreSignup;
+import shop.babsim.babsim.auth.domain.repository.ApplePreSignupRepository;
 import shop.babsim.babsim.global.oauth.config.apple.AppleClientSecretGenerator;
 import shop.babsim.babsim.global.oauth.config.apple.AppleOAuthProperties;
 import shop.babsim.babsim.global.oauth.exception.OAuthException;
@@ -43,6 +46,7 @@ public class AppleAuthService implements AuthService {
     private final AppleClientSecretGenerator appleClientSecretGenerator;
     private final MemberRepository memberRepository;
     private final MemberService memberService;
+    private final ApplePreSignupRepository applePreSignupRepository;
 
     @Override
     public String getProvider() {
@@ -133,7 +137,24 @@ public class AppleAuthService implements AuthService {
         String decodePayload = getDecodePayload(idToken);
 
         try {
-            return objectMapper.readValue(decodePayload, UserInfo.class);
+            JsonNode json = objectMapper.readTree(decodePayload);
+
+            String sub = json.get("sub").asText();
+            String email = json.has("email") ? json.get("email").asText() : null;
+            String name = json.has("name") ? json.get("name").asText() : null;
+
+            if (email != null) {
+                if (!applePreSignupRepository.existsBySub(sub)) {
+                    applePreSignupRepository.save(ApplePreSignup.of(sub, email, name));
+                }
+            } else {
+                email = applePreSignupRepository.findBySub(sub)
+                        .map(ApplePreSignup::getEmail)
+                        .orElseThrow(() -> new OAuthException("Apple email 정보가 없습니다."));
+            }
+
+            return new UserInfo(email, name, null, name);
+
         } catch (JsonProcessingException e) {
             throw new OAuthException("id 토큰을 읽을 수 없습니다.");
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #123 

## 📝작업 내용

> 애플 로그인 회원가입시 최초 idtoken으로 성공하지 못하면, 영구적으로 회원가입을 할 수 없게 되는 현상 해결.

> idToken을 받고 로직을 실행하기 전에 바로 임시 DB에 저장하기



